### PR TITLE
(again) the patch to use 'temp' as slug, if the slug couldn't be generated

### DIFF
--- a/admin/changedata.php
+++ b/admin/changedata.php
@@ -66,7 +66,7 @@ if (isset($_POST['submitted'])) {
 	
 		//check again to see if the URL is empty
 		if ( trim($url) == '' )	{
-			redirect("edit.php?upd=edit-error&type=".urlencode(i18n_r('CANNOT_SAVE_EMPTY')));
+			$url = 'temp';
 		}
 		
 		


### PR DESCRIPTION
For titles that cannot be transliterated, like ":-)" , "...", cirillic-only with no translit available, etc.

With this change, the slug will be 'temp' (or 'temp-1', 'temp-2', ...) in those cases, and the page content will not be lost.
