### PR TITLE
upload.php browse bug

### DIFF
--- a/admin/upload.php
+++ b/admin/upload.php
@@ -16,7 +16,7 @@ login_cookie_check();
 $dirsSorted=null;$filesSorted=null;$foldercount=null;
 
 if (isset($_GET['path'])) {
-	$path = str_replace('../','', $_GET['path']);
+	$path = removerelativepath($_GET['path']);
 	$path = tsl("../data/uploads/".$path);
 	// die if path is outside of uploads
 	if(!path_is_safe($path,GSDATAUPLOADPATH)) die();


### PR DESCRIPTION
The variable <code>$path</code> has a filter bug,
the attacker can browse other directory when he send "....//....//" to server.
