### PR TITLE
Make i18n() fall back on en_US language file.

### DIFF
--- a/admin/inc/basic.php
+++ b/admin/inc/basic.php
@@ -556,16 +556,14 @@ function redirect($url) {
  * @param bool $echo Optional, default is true
  */
 function i18n($name, $echo=true) {
-	global $i18n;
 	global $LANG;
-
-	if (array_key_exists($name, $i18n)) {
-		$myVar = $i18n[$name];
+	$i18n = array();
+	if (array_key_exists($name, $GLOBALS['i18n'])) {
+		$myVar = $GLOBALS['i18n'][$name];
 	} else {
-		# this messes with the global $i18n
-		//include_once(GSLANGPATH . 'en_US.php');
+		@include(GSLANGPATH.'en_US.php');
 		if (array_key_exists($name, $i18n)) {
-			$myVar = $i18n[$name];
+			$myVar = $GLOBALS['i18n'][$name] = $i18n[$name];
 		} else {
 			$myVar = '{'.$name.'}';
 		}


### PR DESCRIPTION
I was looking at how internationalisation was handled when building a plugin and noticed an extra `array_key_exists()` in `i18n()` that wasn’t doing anything. Instead of removing it I decided to patch it up so fallback actually works.

Instead of making `$i18n` global inside the function I access it through `$GLOBALS['i18n']`. This way I was able to include en_US.php without messing up the global variable. If the missing translation exists in en_US.php it is added to the global `$i18n` so it will be found instantly next time.

This does **not** break if someone decides to remove en_US.php, that scenario was tested.

(Feels weird to be working on GetSimple again.)
