### PR TITLE
Update plugin_functions.php

### DIFF
--- a/admin/inc/plugin_functions.php
+++ b/admin/inc/plugin_functions.php
@@ -202,6 +202,8 @@ function create_pluginsxml($force=false){
 		$pluginfiles = getFiles(GSPLUGINPATH,'php');
 	}
 	else return; // plugin files path issue
+	
+	sort($pluginfiles);
 
 	if (!$force) {
 		$livekeys = array_keys($live_plugins);


### PR DESCRIPTION
I have created a multi-part plugin, which preserves the boldness of its settings globally. Unfortunately, it is sometimes the case that the base plugin which provides constants etc. simply is not loaded. The sort command of PHP worerst corrected the problem. Beasser Währe a solution via the PHP file and a folder contained therein statement. It could be global files with settings and paths invite ignoring filenames. One possibility would be to extend the function register_plugin.
