### PR TITLE
fixed Bug

### DIFF
--- a/admin/inc/caching_functions.php
+++ b/admin/inc/caching_functions.php
@@ -92,15 +92,21 @@ function echoPageField($page,$field){
  * 
  */
 function returnPageField($page,$field){   
-	$pagesArray = getPagesXmlValues();	
+	$pagesArray = getPagesXmlValues();
+	$s_page = (string)$page;
 
 	if ($field=="content"){
 		$ret=returnPageContent($page); 
 	} else {
-		if (isset($pagesArray[(string)$page]) && isset($pagesArray[(string)$page][$field]) ){
-			$ret=strip_decode($pagesArray[(string)$page][(string)$field]);
-		} else {
-			$ret = returnPageContent($page,$field);
+		if ( !array_key_exists($s_page, $pagesArray) ) {
+			$ret=false;
+		}
+		else {
+			if (isset($pagesArray[$s_page]) && isset($pagesArray[$s_page][$field]) ){
+				$ret=strip_decode($pagesArray[$s_page][(string)$field]);
+			} else {
+				$ret = returnPageContent($page,$field);
+			}
 		}
 	} 
 	return $ret;


### PR DESCRIPTION
Warning: array_key_exists() expects parameter 2 to be array, null given in /admin/inc/caching_functions.php on line 121

This error occurs when a bookmark is created on a page and this page with this slug is no longer available.
