### PR TITLE
Fix ability to add links to documents in editor

### DIFF
--- a/admin/upload.php
+++ b/admin/upload.php
@@ -323,7 +323,7 @@ function getUploadIcon($type){
 			
 			$counter++;
 			$thumbnailLink = '';
-			$primarylink = '';
+			$primarylink = getRelPath(GSDATAUPLOADPATH).$urlPath. rawurlencode($upload['name']);
 			
 			echo '<tr class="all '.$upload['type'].'" >';
 			echo '<td class="imgthumb" >';
@@ -335,7 +335,6 @@ function getUploadIcon($type){
 				$thumbLink         = $urlPath.'thumbsm.'.$upload['name'];
 				$thumbLinkEncoded  = $urlPath.'thumbsm.'.rawurlencode($upload['name']);
 				$thumbLinkExternal = $urlPath.'thumbnail.'.$upload['name'];
-				$primarylink       = getRelPath(GSDATAUPLOADPATH).$urlPath. rawurlencode($upload['name']);
 
 				// get thumbsm
 				if (!file_exists(GSTHUMBNAILPATH.$thumbLink) || isset($_REQUEST['regenthumbsm'])) {					


### PR DESCRIPTION
in base resulting markup for documents lacks 'data-fileurl' value so it makes impossible to add a link to something except image in creditor file browser. This changes fixes an issue.