### PR TITLE
Allow more flexible plugin (de)activation hook

### DIFF
--- a/admin/inc/plugin_functions.php
+++ b/admin/inc/plugin_functions.php
@@ -130,26 +130,20 @@ function registerInactivePlugins($apilookup = false){
  */
 function change_plugin($name,$active=null){
 	global $live_plugins;
-
-	$name = pathinfo_filename($name).'.php'; // normalize to pluginid
+	
+	$name = pathinfo_filename($name).'.php';
 	if (isset($live_plugins[$name])){
-		// set plugin active | inactive
 		if(isset($active) and is_bool($active)) {
-			$live_plugins[$name] = $active ? 'true' : 'false';
-			create_pluginsxml(true);
-			return;
-		}
-
-		// else we toggle
-		if ($live_plugins[$name]=="true"){
-			$live_plugins[$name]="false";
+			// set plugin active | inactive
+			$active = $active ? "true" : "false";
 		} else {
-			$live_plugins[$name]="true";
+			// else we toggle
+			$active = $live_plugins[$name] == "true" ? "false" : "true";
 		}
-
-		if($live_plugins[$name] == 'false') exec_action('plugin-inactivate'); // @hook plugin-inactivate a plugin was inactivated
-
-		create_pluginsxml(true); // save change; @todo, currently reloads all files and recreates entire xml not just node, is wasteful
+		$live_plugins[$name] = $active;
+		exec_action(($active == "true" ? "" : "de") . "activate-" . substr($name, 0, -4));
+		// save change; @todo, currently reloads all files and recreates entire xml not just node, is wasteful
+		create_pluginsxml(true);
 	}
 }
 


### PR DESCRIPTION
* Allow both plugin 'setup' and 'teardown', instead of just the latter.
* More consistent naming pattern, just like the buttons on the 'Plugins' page ([De]Activate)
* Set the plugin name in the hook, so that it is easy to act upon specific plugins (de-)activation. 
  (open for discussion, could also be [slightly less performant and less] easy if you passed a param to add_action with the function name, then check in if condition)