### PR TITLE
Fix for "A non well formed numeric value"

### DIFF
--- a/admin/inc/basic.php
+++ b/admin/inc/basic.php
@@ -1976,7 +1976,7 @@ function get_site_lang($short=false) {
  * @return string
  */
 function toBytes($str){
-	$val = trim($str);
+	$val = trim($str, 'gmkGMK');
 	$last = strtolower($str[strlen($str)-1]);
 		switch($last) {
 			case 'g': $val *= 1024;


### PR DESCRIPTION
Fix for "A non well formed numeric value encountered" PHP notice, that started to appear with PHP 7.1 when going to "Files" tab in admin panel.