### PR TITLE
Fixed generate salt function

### DIFF
--- a/admin/inc/template_functions.php
+++ b/admin/inc/template_functions.php
@@ -514,8 +514,16 @@ function valid_xml($file) {
  * @return string
  */
 function generate_salt() {
-	return substr(sha1(mt_rand()),0,22);
-}
+  if(version_compare(PHP_VERSION, '5.3.0') >= 0){
+    return bin2hex(openssl_random_pseudo_bytes(16));
+  }else{
+     /* Known to be terribly insecure. Default seeded with an cryptographically
+      * insecure, 32 bit integer, and PHP versions prior to 5.3 lack built in access
+      * to secure random.
+      */
+     return sha1(mt_rand());
+  }
+} 
 
 /**
  * Get Admin Path


### PR DESCRIPTION
Fix on the salt generation function in ./admin/inc/template_functions.php

Still insecure for php 5.2, which does not have built in support for cryptographically secure randomness. 

Things to note:
- I did not update the "updated" string for the function
- I may have goofed on how you handled new lines.
- Tested on Ubuntu 16.04 and PHP 7.0.15
- There still is the slowness issue with Windows up to PHP 5.6. A possibility is to only use secure random generation on PHP 5.6+ or not on Windows. (currently not implemented, as I don't have a Windows box to dev on)

