### PR TITLE
uploadify folder rename

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -147,7 +147,7 @@ if(isset($_POST['submitted'])) {
 				$err .= sprintf(i18n_r('MOVE_TEMPCONFIG_ERROR'), 'temp.gsconfig.php', 'gsconfig.php') . '<br />';
 			}
 		}
-		
+
 		# send email to new administrator
 		$subject  = $site_full_name .' '. i18n_r('EMAIL_COMPLETE');
 		$message .= '<p>'.i18n_r('EMAIL_USERNAME') . ': <strong>'. stripslashes($_POST['user']).'</strong>';
@@ -155,6 +155,16 @@ if(isset($_POST['submitted'])) {
 		$message .= '<br>'. i18n_r('EMAIL_LOGIN') .': <a href="'.$SITEURL.$GSADMIN.'/">'.$SITEURL.$GSADMIN.'/</a></p>';
 		$message .= '<p><em>'. i18n_r('EMAIL_THANKYOU') .' '.$site_full_name.'!</em></p>';
 		$status   = sendmail($EMAIL,$subject,$message);
+
+		# rename uploadify folder
+		$jspath = GSADMINPATH.'template'.DIRECTORY_SEPARATOR.'js'.DIRECTORY_SEPARATOR;
+		if (is_dir($jspath.'uploadify')) {
+			$name = 'uploadify-'.substr(md5(rand()), rand(0,9), 22);
+			if (!@rename($jspath.'uploadify', $jspath.$name)) {
+				$err .= '<strong>'.i18n_r('WARNING').':</strong> Unable to rename folder: <em>'.(defined('GSADMIN') ? GSADMIN : 'admin').'/template/js/uploadify</em>';
+			}
+		}
+
 		# activate default plugins
 		change_plugin('anonymous_data.php',true);
 		change_plugin('InnovationPlugin.php',true);

--- a/admin/template/header.php
+++ b/admin/template/header.php
@@ -5,7 +5,7 @@
  * @package GetSimple
  */
  
-global $SITENAME, $SITEURL;
+global $SITENAME, $SITEURL, $uploadifyfolder;
 
 $GSSTYLE         = getDef('GSSTYLE') ? GSSTYLE : '';
 $GSSTYLE_sbfixed = in_array('sbfixed',explode(',',$GSSTYLE));
@@ -17,6 +17,10 @@ if( $GSSTYLE_wide )    $bodyclass .= " wide";
 $bodyclass .="\"";
 
 if(get_filename_id()!='index') exec_action('admin-pre-header');
+
+/* Find (renamed) uploadify* folder. This is only called below and in sidebar-files.php : */
+$files = glob(GSADMINPATH.DIRECTORY_SEPARATOR.'template'.DIRECTORY_SEPARATOR.'js'.DIRECTORY_SEPARATOR.'uploadify*');
+$uploadifyfolder = basename($files[0]);
 
 ?>
 <!DOCTYPE html>
@@ -40,7 +44,7 @@ if(get_filename_id()!='index') exec_action('admin-pre-header');
 
 	<!--[if lt IE 9]><script type="text/javascript" src="//html5shiv.googlecode.com/svn/trunk/html5.js" ></script><![endif]-->
 	<?php if( ((get_filename_id()=='upload') || (get_filename_id()=='image')) && (!getDef('GSNOUPLOADIFY',true)) ) { ?>
-	<script type="text/javascript" src="template/js/uploadify/jquery.uploadify.js?v=3.0"></script>
+	<script type="text/javascript" src="template/js/<?php echo $uploadifyfolder; ?>/jquery.uploadify.js?v=3.0"></script>
 	<?php } ?>
 	<?php if(get_filename_id()=='image') { ?>
 	<script type="text/javascript" src="template/js/jcrop/jquery.Jcrop.min.js"></script>

--- a/admin/template/sidebar-files.php
+++ b/admin/template/sidebar-files.php
@@ -30,7 +30,7 @@ $path = (isset($_GET['path'])) ? $_GET['path'] : "";
 			'buttonText'	: '". i18n_r('UPLOADIFY_BUTTON') ."',
 			'buttonCursor'	: 'pointer',
 			'uploader'		: 'upload-uploadify.php',
-			'swf'			: 'template/js/uploadify/uploadify.swf',
+			'swf'			: 'template/js/". $uploadifyfolder ."/uploadify.swf',
 			'multi'			: true,
 			'auto'			: true,
 			'height'		: '25',

--- a/admin/update.php
+++ b/admin/update.php
@@ -120,7 +120,7 @@ if (file_exists(GSDATAOTHERPATH .'user.xml')) {
 	}
 	
 	
-	# rename old wesbite.xml
+	# rename old website.xml
 	if (!file_exists(GSDATAOTHERPATH .'_legacy_website.xml')) {
 		$status = rename(GSDATAOTHERPATH .'website.xml', GSDATAOTHERPATH .'_legacy_website.xml');
 		if (!$status) {
@@ -165,7 +165,16 @@ if (file_exists(GSDATAOTHERPATH .'user.xml')) {
 		}
 	}
 	/* end update */
-} 
+}
+
+# rename uploadify folder
+$jspath = GSADMINPATH.'template'.DIRECTORY_SEPARATOR.'js'.DIRECTORY_SEPARATOR;
+if (is_dir($jspath.'uploadify')) {
+  $name = 'uploadify-'.substr(md5(rand()), rand(0,9), 22);
+	if (!@rename($jspath.'uploadify', $jspath.$name)) {
+		$message .= msgError('Unable to rename folder: <em>'.(defined('GSADMIN') ? GSADMIN : 'admin').'/template/js/uploadify</em>');
+	}
+}
 
 // redirect to health check or login and show updated notice
 $redirect = cookie_check() ? "health-check.php?updated=1" : "index.php?updated=1";


### PR DESCRIPTION
(draft) possible fix for issue 1266 (uploadify xss)
- renames uploadify folder (adds random suffix) on install (setup) or update
- file manager looks for the uploadify* folder
