### PR TITLE
Add gs-<GSVERSION> class to body

### DIFF
--- a/admin/template/header.php
+++ b/admin/template/header.php
@@ -15,7 +15,7 @@ $GSSTYLE_wide    = in_array('wide',explode(',',$GSSTYLE));
 $GSSTYLE_trans   = in_array('trans',explode(',',$GSSTYLE));
 
 // set up body classes
-$bodyclass='';
+$bodyclass= "gs-" . GSVERSION;
 if( $GSSTYLE_sbfixed )          $bodyclass .= " sbfixed";
 if( $GSSTYLE_wide )             $bodyclass .= " wide";
 if( $GSSTYLE_trans )            $bodyclass .= " trans";


### PR DESCRIPTION
Adding a `gs-3.4.0a` class to the body allows plugins to maintain compatibility with recent/ future GS version CSS changes by prefixing CSS rules like `.gs-3\.4\.0a .notify { ... }` or `[class*="gs-3.4.0a"] { ... }`

Open for discussion: whether to replace the dots in the version with dashes/ underscores for easier CSS rule writing