### PR TITLE
Fix for getMaxUploadSize()

### DIFF
--- a/admin/inc/basic.php
+++ b/admin/inc/basic.php
@@ -2941,7 +2941,10 @@ function getMaxUploadSize(){
 	$max_upload   = toBytes(ini_get('upload_max_filesize'));
 	$max_post     = toBytes(ini_get('post_max_size'));
 	$memory_limit = toBytes(ini_get('memory_limit'));
-	$upload_mb    = min($max_upload, $max_post, $memory_limit);
+	if($max_post == 0)
+		$upload_mb = min($max_upload, $memory_limit);
+	else
+		$upload_mb = min($max_upload, $max_post, $memory_limit);
 	return $upload_mb;
 }
 


### PR DESCRIPTION
getMaxUploadSize() returns 0 when post_max_size is set to 0. It shouldn't do this, as setting post_max_size to 0 does not limit max post size, but actually removes maximum post limit altogether. From the php.ini:
; Maximum size of POST data that PHP will accept.
; Its value may be 0 to disable the limit.