### PR TITLE
Fix a missing comma typo

### DIFF
--- a/admin/inc/security_functions.php
+++ b/admin/inc/security_functions.php
@@ -29,7 +29,7 @@ $file_ext_blacklist = array(
 	# HTML may contain cookie-stealing JavaScript and web bugs
 	'html', 'htm', 'js', 'jsb', 'mhtml', 'mht',
 	# PHP scripts may execute arbitrary code on the server
-	'php', 'pht', 'phtm', 'phtml', 'php3', 'php4', 'php5', 'ph3', 'ph4', 'ph5', 'phps','phar'
+	'php', 'pht', 'phtm', 'phtml', 'php3', 'php4', 'php5', 'ph3', 'ph4', 'ph5', 'phps','phar', //added a missing comma after 'phar'
 	# Other types that may be interpreted by some servers
 	'shtml', 'jhtml', 'pl', 'py', 'cgi', 'sh', 'ksh', 'bsh', 'c', 'htaccess', 'htpasswd',
 	# May contain harmful executables for Windows victims


### PR DESCRIPTION
Got this error ` Parse error: syntax error, unexpected ''shtml'' (T_CONSTANT_ENCAPSED_STRING), expecting ')' in /var/www/html/GetSimpleCMS/admin/inc/security_functions.php on line 34` because of that missing comma in line 34 :)